### PR TITLE
fix: keep a window in place when focus switches

### DIFF
--- a/src/components/os/WindowLayer.tsx
+++ b/src/components/os/WindowLayer.tsx
@@ -24,11 +24,17 @@ function SnapPreview({ zone }: { zone: Exclude<SnapZone, null> }) {
 }
 
 export function WindowLayer() {
-  const { windows, focusedId } = useWindowManager();
+  // Deliberately the unsorted list. `windows` from the context is sorted by
+  // z-order, so raising a window reorders the DOM nodes; the browser then
+  // replays the enter animation on the moved element. Stacking is already
+  // handled by the inline `z-index` each frame sets, so render order is free
+  // to stay stable.
+  const { state, focusedId } = useWindowManager();
+  const windows = state.windows;
   const [snap, setSnap] = useState<SnapZone>(null);
 
   return (
-    <div className="os-window-enter pointer-events-none absolute inset-0">
+    <div className="pointer-events-none absolute inset-0">
       {snap && <SnapPreview zone={snap} />}
 
       {windows.map((win) => {

--- a/src/index.css
+++ b/src/index.css
@@ -308,14 +308,20 @@ body.os-dragging .os-window-content {
 
 /* ------------------------------------------------------------- Animations */
 
+/*
+ * Windows carry their position in an inline `transform: translate3d(...)`, so
+ * the opening animation must not touch `transform` — animating it would pin
+ * the window at 0,0 for the duration. The standalone `scale` property
+ * composes with the inline transform instead of replacing it.
+ */
 @keyframes os-window-in {
   from {
     opacity: 0;
-    transform: scale(0.96);
+    scale: 0.96;
   }
   to {
     opacity: 1;
-    transform: scale(1);
+    scale: 1;
   }
 }
 
@@ -328,7 +334,7 @@ body.os-dragging .os-window-content {
   }
 }
 
-.os-window-enter > * {
+.os-window {
   animation: os-window-in 160ms cubic-bezier(0.22, 1, 0.36, 1);
 }
 
@@ -339,9 +345,6 @@ body.os-dragging .os-window-content {
 @media (prefers-reduced-motion: reduce) {
   .os-window {
     transition: none;
-  }
-
-  .os-window-enter > * {
     animation: os-fade-in 120ms ease-out;
   }
 }


### PR DESCRIPTION
Fixes #13

## What was wrong

Clicking an unfocused window made it jump to the top-left corner and animate back to its real position.

Two causes combined:

1. `@keyframes os-window-in` animated `transform: scale(...)`, but a window's position is applied as an inline `transform: translate3d(x, y, 0)` on `.os-window`. While the animation ran, the keyframes' transform replaced the inline one entirely, so the window rendered at 0,0.
2. `WindowLayer` rendered `windows` from the context, which is sorted by z-order. Raising a window therefore reordered its DOM node, and the browser replays a CSS animation on an element that is moved in the DOM — so the animation re-ran on every focus switch, not just on open.

The animation selector `.os-window-enter > *` also caught the snap preview, which is positioned with the same inline `translate3d` and had the same problem.

## The fix

- Animate the standalone `scale` property instead of `transform`. It composes with the inline transform rather than replacing it.
- Scope the animation to `.os-window` instead of every direct child of the window layer.
- Render windows in their stable creation order. Stacking is already handled by the inline `z-index` each frame sets, so render order does not need to follow z.

## Verification

Sampling the clicked window's `getBoundingClientRect()` every frame for 400 ms after a focus switch, with two overlapping windows in Chrome:

- **Before** — positions seen: `374,189` → `0,28`, `0,29`, `1,30`, … `9,40` (the jump and the animation back)
- **After** — one position across all 47 frames: `108,136`

`npm test` (tsc, eslint, vitest, build) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Trku191Ww2a2YmDWQF3fTS