### PR TITLE
fix: open the picked app from the mobile app switcher

### DIFF
--- a/src/components/os/MobileAppShell.tsx
+++ b/src/components/os/MobileAppShell.tsx
@@ -21,8 +21,16 @@ import { cn } from '@/lib/utils';
  * app at a time.
  */
 export function MobileAppShell() {
-  const { windows, focusedId, openApp, focusWindow, closeWindow, setWindowTitle, setWindowParams } =
-    useWindowManager();
+  const {
+    windows,
+    focusedId,
+    openApp,
+    focusWindow,
+    restoreWindow,
+    closeWindow,
+    setWindowTitle,
+    setWindowParams,
+  } = useWindowManager();
   const [switcherOpen, setSwitcherOpen] = useState(false);
 
   const active = useMemo(
@@ -74,7 +82,11 @@ export function MobileAppShell() {
                       key={win.id}
                       type="button"
                       onClick={() => {
-                        focusWindow(win.id);
+                        // Focusing alone leaves a minimized window minimized,
+                        // and the shell only renders a window that is focused
+                        // *and* not minimized — the home screen would stay up.
+                        if (win.minimized) restoreWindow(win.id);
+                        else focusWindow(win.id);
                         setSwitcherOpen(false);
                       }}
                       className={cn(


### PR DESCRIPTION
Fixes #15

## What was wrong

Picking an app in the mobile "Open apps" switcher called `focusWindow(win.id)`. `FOCUS_WINDOW` → `raise()` bumps `z` and sets `focusedId`, but never clears `minimized`. The mobile shell renders a window only when it is focused **and** not minimized:

```ts
const active = windows.find((win) => win.id === focusedId && !win.minimized);
```

So picking a minimized app left `active` undefined and the home screen on screen, while the URL and document title — which follow `focusedId` — had already switched to the selected app.

## The fix

Restore a minimized window instead of merely focusing it. The menu bar's Window menu (`MenuBar.tsx:136`) and the command palette (`CommandPalette.tsx:49`) already do exactly this; the switcher was the one place that did not.

## Verification

Chrome at 400x800, with a persisted session where every window is minimized and `focusedId` is null:

- **Before** — tapping "Feed — Following" set the URL to `?app=feed` and the title to "Feed — Following", but the home screen stayed up.
- **After** — the sheet closes and Feed opens full-screen.

`npm test` (tsc, eslint, vitest, build) passes.

Note: reproducing this by hand needs #14's fix in the tree as well, since the switcher crashes on `main` when an app is already open. The two fixes are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Trku191Ww2a2YmDWQF3fTS