### PR TITLE
feat: web bookmarks for arbitrary URLs (NIP-B0)

### DIFF
--- a/docs/apps.md
+++ b/docs/apps.md
@@ -89,7 +89,7 @@ export default function ExampleApp({ setTitle }: AppProps) {
 }
 ```
 
-## The seven apps
+## The eight apps
 
 | App | `id` | Params | Notes |
 |---|---|---|---|
@@ -97,9 +97,18 @@ export default function ExampleApp({ setTitle }: AppProps) {
 | Profile | `profile` | `pubkey`, `relays?` | kind 0 metadata, the author's notes, follow/unfollow |
 | Note | `notes` | `id`, `relays?` | One note and its replies. **Not** a singleton |
 | Reader | `articles` | `pubkey?`, `identifier?`, `kind?`, `relays?` | NIP-23 long-form, `react-markdown` |
+| Web Bookmarks | `web-bookmarks` | — | NIP-B0 kind 39701 — one addressable event per saved URL |
 | Relays | `relays` | — | Connection state, subscription count, measured latency |
 | Settings | `settings` | — | Theme, relay list, Blossom servers, account, session |
 | About | `about` | — | What this is, the app list, the shortcuts |
+
+### Web bookmarks are one event per URL, not a list
+
+Unlike a NIP-51 list, each NIP-B0 web bookmark (kind 39701) is its own addressable event —
+the `d` tag is the URL itself (scheme stripped for `https`, see `bookmarkDTag` in
+`src/hooks/useWebBookmarks.ts`). Removing one publishes a NIP-09 kind 5 deletion request,
+which relays are free to ignore, so the client also drops it from its own query cache
+rather than trusting a refetch to reflect it.
 
 ### Follow lists are a whole-list replacement
 

--- a/src/apps/web-bookmarks/index.tsx
+++ b/src/apps/web-bookmarks/index.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useState } from 'react';
+import type { NostrEvent } from '@nostrify/nostrify';
+import { ExternalLink, Loader2, Plus, X } from 'lucide-react';
+import { AppBody, AppLayout, AppToolbar, EmptyState } from '@/components/os/AppChrome';
+import { LoginRequired } from '@/components/nostr/LoginRequired';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Textarea } from '@/components/ui/textarea';
+import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { useToast } from '@/hooks/useToast';
+import {
+  bookmarkUrl,
+  useCreateWebBookmark,
+  useDeleteWebBookmark,
+  useMyWebBookmarks,
+  webBookmarkTopics,
+} from '@/hooks/useWebBookmarks';
+import { relativeTime, sanitizeUrl, tagValue } from '@/lib/nostrUtils';
+import type { AppProps } from '@/os/types';
+
+export default function WebBookmarksApp({ setTitle }: AppProps) {
+  const { user } = useCurrentUser();
+  const [formOpen, setFormOpen] = useState(false);
+
+  useEffect(() => setTitle('Web Bookmarks'), [setTitle]);
+
+  const bookmarks = useMyWebBookmarks();
+
+  if (!user) {
+    return <LoginRequired action="save web bookmarks" />;
+  }
+
+  return (
+    <AppLayout>
+      <AppToolbar>
+        <span className="text-[13px] font-medium">Web Bookmarks</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="ml-auto h-7 gap-1.5 px-2 text-xs"
+          onClick={() => setFormOpen((open) => !open)}
+        >
+          {formOpen ? <X className="size-3.5" aria-hidden /> : <Plus className="size-3.5" aria-hidden />}
+          {formOpen ? 'Cancel' : 'Add bookmark'}
+        </Button>
+      </AppToolbar>
+
+      <AppBody>
+        {formOpen && <NewBookmarkForm onDone={() => setFormOpen(false)} />}
+
+        {bookmarks.isLoading ? (
+          <div className="space-y-3 p-4">
+            {Array.from({ length: 4 }).map((_, index) => (
+              <Skeleton key={index} className="h-16 w-full" />
+            ))}
+          </div>
+        ) : bookmarks.data && bookmarks.data.length > 0 ? (
+          bookmarks.data.map((event) => <WebBookmarkRow key={event.id} event={event} />)
+        ) : (
+          <EmptyState
+            title="No web bookmarks yet"
+            hint="Save a link and it will show up here."
+            action={
+              !formOpen && (
+                <Button size="sm" onClick={() => setFormOpen(true)}>
+                  Add a bookmark
+                </Button>
+              )
+            }
+          />
+        )}
+      </AppBody>
+    </AppLayout>
+  );
+}
+
+function NewBookmarkForm({ onDone }: { onDone: () => void }) {
+  const [url, setUrl] = useState('');
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [tags, setTags] = useState('');
+  const create = useCreateWebBookmark();
+  const { toast } = useToast();
+
+  const trimmedUrl = url.trim();
+  const isValid = /^https?:\/\/.+/i.test(trimmedUrl);
+
+  const submit = async () => {
+    if (!isValid) return;
+    try {
+      await create.mutateAsync({
+        url: trimmedUrl,
+        title: title.trim() || undefined,
+        description: description.trim() || undefined,
+        tags: tags
+          .split(',')
+          .map((tag) => tag.trim())
+          .filter(Boolean),
+      });
+      toast({ title: 'Bookmark saved' });
+      onDone();
+    } catch (error) {
+      toast({
+        title: 'Could not save bookmark',
+        description: error instanceof Error ? error.message : 'No relay accepted the update.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-2.5 border-b border-border px-4 py-3">
+      <Input
+        value={url}
+        onChange={(event) => setUrl(event.target.value)}
+        placeholder="https://…"
+        autoFocus
+        aria-invalid={url.length > 0 && !isValid}
+      />
+      <Input value={title} onChange={(event) => setTitle(event.target.value)} placeholder="Title (optional)" />
+      <Textarea
+        value={description}
+        onChange={(event) => setDescription(event.target.value)}
+        placeholder="Description (optional)"
+        rows={2}
+        className="min-h-16 resize-none text-[14px]"
+      />
+      <Input
+        value={tags}
+        onChange={(event) => setTags(event.target.value)}
+        placeholder="Tags, comma separated (optional)"
+      />
+      <div className="flex justify-end">
+        <Button size="sm" onClick={submit} disabled={!isValid || create.isPending} className="gap-1.5">
+          {create.isPending && <Loader2 className="size-3.5 animate-spin" aria-hidden />}
+          Save bookmark
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function WebBookmarkRow({ event }: { event: NostrEvent }) {
+  const del = useDeleteWebBookmark();
+  const { toast } = useToast();
+
+  const dTag = tagValue(event, 'd') ?? '';
+  const url = sanitizeUrl(bookmarkUrl(dTag)) ?? bookmarkUrl(dTag);
+  const title = tagValue(event, 'title') ?? dTag;
+  const topics = webBookmarkTopics(event);
+
+  const handleDelete = async () => {
+    try {
+      await del.mutateAsync(event);
+      toast({ title: 'Bookmark removed' });
+    } catch (error) {
+      toast({
+        title: 'Could not remove bookmark',
+        description: error instanceof Error ? error.message : 'No relay accepted the update.',
+        variant: 'destructive',
+      });
+    }
+  };
+
+  return (
+    <article className="group border-b border-border px-4 py-3 transition-colors last:border-b-0 hover:bg-muted/40">
+      <div className="flex items-start justify-between gap-3">
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex min-w-0 items-center gap-1.5 text-[14px] font-medium hover:underline"
+        >
+          <span className="truncate">{title}</span>
+          <ExternalLink className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+        </a>
+        <span className="shrink-0 text-xs text-muted-foreground">{relativeTime(event.created_at)}</span>
+      </div>
+
+      <p className="mt-0.5 truncate text-xs text-muted-foreground">{dTag}</p>
+
+      {event.content && <p className="mt-1.5 text-[13px] leading-relaxed">{event.content}</p>}
+
+      <div className="mt-2 flex flex-wrap items-center gap-1.5">
+        {topics.map((topic) => (
+          <Badge key={topic} variant="secondary" className="text-[11px]">
+            {topic}
+          </Badge>
+        ))}
+        <Button
+          variant="ghost"
+          size="sm"
+          className="ml-auto h-6 gap-1 px-1.5 text-xs text-muted-foreground opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100"
+          onClick={handleDelete}
+          disabled={del.isPending}
+        >
+          {del.isPending ? <Loader2 className="size-3 animate-spin" aria-hidden /> : <X className="size-3" aria-hidden />}
+          Remove
+        </Button>
+      </div>
+    </article>
+  );
+}

--- a/src/apps/web-bookmarks/index.tsx
+++ b/src/apps/web-bookmarks/index.tsx
@@ -20,6 +20,21 @@ import {
 import { relativeTime, sanitizeUrl, tagValue } from '@/lib/nostrUtils';
 import type { AppProps } from '@/os/types';
 
+/**
+ * Same protocol allowlist as sanitizeUrl(), but for an absolute bookmark URL
+ * rather than an href/src that may legitimately be relative to this app's
+ * own origin — sanitizeUrl() would resolve a bare "example.com" against
+ * `window.location.origin` and "validate" it as a link back into this app.
+ */
+const BOOKMARKABLE_SCHEMES = new Set(['https:', 'http:', 'mailto:', 'nostr:']);
+function isBookmarkableUrl(value: string): boolean {
+  try {
+    return BOOKMARKABLE_SCHEMES.has(new URL(value).protocol);
+  } catch {
+    return false;
+  }
+}
+
 export default function WebBookmarksApp({ setTitle }: AppProps) {
   const { user } = useCurrentUser();
   const [formOpen, setFormOpen] = useState(false);
@@ -85,7 +100,7 @@ function NewBookmarkForm({ onDone }: { onDone: () => void }) {
   const { toast } = useToast();
 
   const trimmedUrl = url.trim();
-  const isValid = /^https?:\/\/.+/i.test(trimmedUrl);
+  const isValid = isBookmarkableUrl(trimmedUrl);
 
   const submit = async () => {
     if (!isValid) return;
@@ -147,7 +162,11 @@ function WebBookmarkRow({ event }: { event: NostrEvent }) {
   const { toast } = useToast();
 
   const dTag = tagValue(event, 'd') ?? '';
-  const url = sanitizeUrl(bookmarkUrl(dTag)) ?? bookmarkUrl(dTag);
+  // sanitizeUrl() returning undefined means the reconstructed URL uses a
+  // protocol that could execute script (e.g. a malicious "d" tag) — in that
+  // case there is no safe href to link out to, full stop, not a fallback to
+  // the very value that just failed sanitization.
+  const url = sanitizeUrl(bookmarkUrl(dTag));
   const title = tagValue(event, 'title') ?? dTag;
   const topics = webBookmarkTopics(event);
 
@@ -167,15 +186,21 @@ function WebBookmarkRow({ event }: { event: NostrEvent }) {
   return (
     <article className="group border-b border-border px-4 py-3 transition-colors last:border-b-0 hover:bg-muted/40">
       <div className="flex items-start justify-between gap-3">
-        <a
-          href={url}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex min-w-0 items-center gap-1.5 text-[14px] font-medium hover:underline"
-        >
-          <span className="truncate">{title}</span>
-          <ExternalLink className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
-        </a>
+        {url ? (
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex min-w-0 items-center gap-1.5 text-[14px] font-medium hover:underline"
+          >
+            <span className="truncate">{title}</span>
+            <ExternalLink className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+          </a>
+        ) : (
+          <span className="truncate text-[14px] font-medium text-muted-foreground" title="Not a safe URL to open">
+            {title}
+          </span>
+        )}
         <span className="shrink-0 text-xs text-muted-foreground">{relativeTime(event.created_at)}</span>
       </div>
 

--- a/src/hooks/useWebBookmarks.test.ts
+++ b/src/hooks/useWebBookmarks.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { bookmarkDTag, bookmarkUrl } from './useWebBookmarks';
+import type { NostrEvent } from '@nostrify/nostrify';
+import { bookmarkDTag, bookmarkUrl, dedupeLatestByDTag } from './useWebBookmarks';
+
+function bookmarkEvent(dTag: string, createdAt: number, id = `${dTag}-${createdAt}`): NostrEvent {
+  return { id, pubkey: 'author', created_at: createdAt, kind: 39701, tags: [['d', dTag]], content: '', sig: '' };
+}
 
 describe('bookmarkDTag / bookmarkUrl', () => {
   it('strips the https scheme per NIP-B0', () => {
@@ -39,5 +44,32 @@ describe('bookmarkDTag / bookmarkUrl', () => {
 
   it('does not mistake a port number in a stripped https URL for a scheme', () => {
     expect(bookmarkUrl('alice.blog:8080/post')).toBe('https://alice.blog:8080/post');
+  });
+});
+
+describe('dedupeLatestByDTag', () => {
+  it('keeps only the newest event for each d tag', () => {
+    const older = bookmarkEvent('alice.blog/post', 100);
+    const newer = bookmarkEvent('alice.blog/post', 200);
+    const result = dedupeLatestByDTag([older, newer]);
+    expect(result).toEqual([newer]);
+  });
+
+  it('is order-independent', () => {
+    const older = bookmarkEvent('alice.blog/post', 100);
+    const newer = bookmarkEvent('alice.blog/post', 200);
+    expect(dedupeLatestByDTag([newer, older])).toEqual([newer]);
+  });
+
+  it('keeps distinct d tags separately, sorted newest first', () => {
+    const a = bookmarkEvent('a.com', 100);
+    const b = bookmarkEvent('b.com', 300);
+    const c = bookmarkEvent('c.com', 200);
+    expect(dedupeLatestByDTag([a, b, c])).toEqual([b, c, a]);
+  });
+
+  it('drops events with no d tag', () => {
+    const noD: NostrEvent = { id: 'x', pubkey: 'author', created_at: 0, kind: 39701, tags: [], content: '', sig: '' };
+    expect(dedupeLatestByDTag([noD])).toEqual([]);
   });
 });

--- a/src/hooks/useWebBookmarks.test.ts
+++ b/src/hooks/useWebBookmarks.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { bookmarkDTag, bookmarkUrl } from './useWebBookmarks';
+
+describe('bookmarkDTag / bookmarkUrl', () => {
+  it('strips the https scheme per NIP-B0', () => {
+    expect(bookmarkDTag('https://alice.blog/post')).toBe('alice.blog/post');
+  });
+
+  it('keeps non-https schemes in full', () => {
+    expect(bookmarkDTag('http://alice.blog/post')).toBe('http://alice.blog/post');
+    expect(bookmarkDTag('gemini://example.com/')).toBe('gemini://example.com/');
+  });
+
+  it('round-trips an https URL back through bookmarkUrl', () => {
+    const url = 'https://alice.blog/post';
+    expect(bookmarkUrl(bookmarkDTag(url))).toBe(url);
+  });
+
+  it('round-trips a non-https URL back through bookmarkUrl', () => {
+    const url = 'http://alice.blog/post';
+    expect(bookmarkUrl(bookmarkDTag(url))).toBe(url);
+  });
+});

--- a/src/hooks/useWebBookmarks.test.ts
+++ b/src/hooks/useWebBookmarks.test.ts
@@ -26,4 +26,18 @@ describe('bookmarkDTag / bookmarkUrl', () => {
     expect(bookmarkDTag('HtTpS://alice.blog/post')).toBe('alice.blog/post');
     expect(bookmarkDTag('HTTPS://alice.blog/post')).toBe(bookmarkDTag('https://alice.blog/post'));
   });
+
+  it('round-trips schemes with no "//", like mailto: and nostr:, instead of prefixing them with https://', () => {
+    expect(bookmarkUrl(bookmarkDTag('mailto:hello@example.com'))).toBe('mailto:hello@example.com');
+    expect(bookmarkUrl(bookmarkDTag('nostr:npub1abc'))).toBe('nostr:npub1abc');
+  });
+
+  it('round-trips a hierarchical non-https scheme like gemini://', () => {
+    const url = 'gemini://example.com/';
+    expect(bookmarkUrl(bookmarkDTag(url))).toBe(url);
+  });
+
+  it('does not mistake a port number in a stripped https URL for a scheme', () => {
+    expect(bookmarkUrl('alice.blog:8080/post')).toBe('https://alice.blog:8080/post');
+  });
 });

--- a/src/hooks/useWebBookmarks.test.ts
+++ b/src/hooks/useWebBookmarks.test.ts
@@ -20,4 +20,10 @@ describe('bookmarkDTag / bookmarkUrl', () => {
     const url = 'http://alice.blog/post';
     expect(bookmarkUrl(bookmarkDTag(url))).toBe(url);
   });
+
+  it('strips the https scheme case-insensitively, so casing does not create duplicate bookmarks', () => {
+    expect(bookmarkDTag('HTTPS://alice.blog/post')).toBe('alice.blog/post');
+    expect(bookmarkDTag('HtTpS://alice.blog/post')).toBe('alice.blog/post');
+    expect(bookmarkDTag('HTTPS://alice.blog/post')).toBe(bookmarkDTag('https://alice.blog/post'));
+  });
 });

--- a/src/hooks/useWebBookmarks.ts
+++ b/src/hooks/useWebBookmarks.ts
@@ -44,6 +44,22 @@ export interface WebBookmarkInput {
   tags?: string[];
 }
 
+/**
+ * Addressable events: relays across the pool can hand back more than one
+ * revision of the same `d` tag (an edit history, or just multiple relays
+ * disagreeing on what's current). Keeps only the newest per `d`, newest first.
+ */
+export function dedupeLatestByDTag(events: NostrEvent[]): NostrEvent[] {
+  const latest = new Map<string, NostrEvent>();
+  for (const event of events) {
+    const dTag = tagValue(event, 'd');
+    if (!dTag) continue;
+    const current = latest.get(dTag);
+    if (!current || event.created_at > current.created_at) latest.set(dTag, event);
+  }
+  return [...latest.values()].sort((a, b) => b.created_at - a.created_at);
+}
+
 export function useMyWebBookmarks() {
   const { nostr } = useNostr();
   const { user } = useCurrentUser();
@@ -56,9 +72,7 @@ export function useMyWebBookmarks() {
         [{ kinds: [WEB_BOOKMARK_KIND], authors: [user!.pubkey], limit: 200 }],
         { signal: AbortSignal.any([signal, AbortSignal.timeout(6000)]) },
       );
-      return events
-        .filter((event) => Boolean(tagValue(event, 'd')))
-        .sort((a, b) => b.created_at - a.created_at);
+      return dedupeLatestByDTag(events);
     },
     staleTime: 60_000,
   });

--- a/src/hooks/useWebBookmarks.ts
+++ b/src/hooks/useWebBookmarks.ts
@@ -24,9 +24,17 @@ export function bookmarkDTag(url: string): string {
   return HTTPS_SCHEME_RE.test(url) ? url.slice('https://'.length) : url;
 }
 
+/** Hierarchical URIs, e.g. `http://…` or `gemini://…` — the `//` is what rules out a false match on a stripped https URL that happens to contain a port, e.g. `alice.blog:8080/post`. */
+const HIERARCHICAL_SCHEME_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+/** Non-hierarchical URIs with no `//`, e.g. `mailto:` and `nostr:` — not matched by the pattern above. */
+const OPAQUE_SCHEMES = ['mailto:', 'nostr:'];
+
 /** Reconstructs a clickable URL from a `d` tag written by `bookmarkDTag`. */
 export function bookmarkUrl(dTag: string): string {
-  return /^[a-z][a-z0-9+.-]*:\/\//i.test(dTag) ? dTag : `https://${dTag}`;
+  const lower = dTag.toLowerCase();
+  const alreadyHasScheme =
+    HIERARCHICAL_SCHEME_RE.test(dTag) || OPAQUE_SCHEMES.some((scheme) => lower.startsWith(scheme));
+  return alreadyHasScheme ? dTag : `https://${dTag}`;
 }
 
 export interface WebBookmarkInput {
@@ -57,6 +65,7 @@ export function useMyWebBookmarks() {
 }
 
 export function useCreateWebBookmark() {
+  const { nostr } = useNostr();
   const { user } = useCurrentUser();
   const publish = useNostrPublish();
   const queryClient = useQueryClient();
@@ -65,12 +74,25 @@ export function useCreateWebBookmark() {
     mutationFn: async ({ url, title, description, tags }: WebBookmarkInput) => {
       if (!user) throw new Error('Sign in to bookmark a page');
 
-      const eventTags: string[][] = [['d', bookmarkDTag(url)]];
+      const dTag = bookmarkDTag(url);
+      // Re-bookmarking an already-saved URL is an edit of the same
+      // addressable event, not a new bookmark — published_at per NIP-B0 is
+      // "the first time the bookmark was published", so it must carry over
+      // rather than being reset to now on every edit.
+      const [existing] = await nostr.query(
+        [{ kinds: [WEB_BOOKMARK_KIND], authors: [user.pubkey], '#d': [dTag], limit: 1 }],
+        { signal: AbortSignal.timeout(6000) },
+      );
+      const publishedAt = existing
+        ? (tagValue(existing, 'published_at') ?? String(existing.created_at))
+        : String(Math.floor(Date.now() / 1000));
+
+      const eventTags: string[][] = [['d', dTag]];
       if (title?.trim()) eventTags.push(['title', title.trim()]);
       for (const tag of tags ?? []) {
         if (tag.trim()) eventTags.push(['t', tag.trim().toLowerCase()]);
       }
-      eventTags.push(['published_at', String(Math.floor(Date.now() / 1000))]);
+      eventTags.push(['published_at', publishedAt]);
 
       return publish.mutateAsync({
         kind: WEB_BOOKMARK_KIND,

--- a/src/hooks/useWebBookmarks.ts
+++ b/src/hooks/useWebBookmarks.ts
@@ -12,12 +12,16 @@ function queryKey(pubkey: string | undefined) {
   return ['nostr', 'web-bookmarks', pubkey ?? ''] as const;
 }
 
+const HTTPS_SCHEME_RE = /^https:\/\//i;
+
 /**
  * The `d` tag per NIP-B0: the URI with the `https://` scheme stripped (every
  * other scheme keeps its full form, so it round-trips through `bookmarkUrl`).
+ * The scheme match is case-insensitive so "HTTPS://" and "https://" collapse
+ * to the same `d` tag instead of creating duplicate bookmarks.
  */
 export function bookmarkDTag(url: string): string {
-  return url.startsWith('https://') ? url.slice('https://'.length) : url;
+  return HTTPS_SCHEME_RE.test(url) ? url.slice('https://'.length) : url;
 }
 
 /** Reconstructs a clickable URL from a `d` tag written by `bookmarkDTag`. */

--- a/src/hooks/useWebBookmarks.ts
+++ b/src/hooks/useWebBookmarks.ts
@@ -1,0 +1,118 @@
+import { useNostr } from '@nostrify/react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { NostrEvent } from '@nostrify/nostrify';
+import { useCurrentUser } from './useCurrentUser';
+import { useNostrPublish } from './useNostrPublish';
+import { tagValue, tagValues } from '@/lib/nostrUtils';
+
+/** NIP-B0 "Web Bookmarking": one addressable event per bookmarked URL. */
+export const WEB_BOOKMARK_KIND = 39701;
+
+function queryKey(pubkey: string | undefined) {
+  return ['nostr', 'web-bookmarks', pubkey ?? ''] as const;
+}
+
+/**
+ * The `d` tag per NIP-B0: the URI with the `https://` scheme stripped (every
+ * other scheme keeps its full form, so it round-trips through `bookmarkUrl`).
+ */
+export function bookmarkDTag(url: string): string {
+  return url.startsWith('https://') ? url.slice('https://'.length) : url;
+}
+
+/** Reconstructs a clickable URL from a `d` tag written by `bookmarkDTag`. */
+export function bookmarkUrl(dTag: string): string {
+  return /^[a-z][a-z0-9+.-]*:\/\//i.test(dTag) ? dTag : `https://${dTag}`;
+}
+
+export interface WebBookmarkInput {
+  url: string;
+  title?: string;
+  description?: string;
+  tags?: string[];
+}
+
+export function useMyWebBookmarks() {
+  const { nostr } = useNostr();
+  const { user } = useCurrentUser();
+
+  return useQuery<NostrEvent[]>({
+    queryKey: queryKey(user?.pubkey),
+    enabled: Boolean(user),
+    queryFn: async ({ signal }) => {
+      const events = await nostr.query(
+        [{ kinds: [WEB_BOOKMARK_KIND], authors: [user!.pubkey], limit: 200 }],
+        { signal: AbortSignal.any([signal, AbortSignal.timeout(6000)]) },
+      );
+      return events
+        .filter((event) => Boolean(tagValue(event, 'd')))
+        .sort((a, b) => b.created_at - a.created_at);
+    },
+    staleTime: 60_000,
+  });
+}
+
+export function useCreateWebBookmark() {
+  const { user } = useCurrentUser();
+  const publish = useNostrPublish();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ url, title, description, tags }: WebBookmarkInput) => {
+      if (!user) throw new Error('Sign in to bookmark a page');
+
+      const eventTags: string[][] = [['d', bookmarkDTag(url)]];
+      if (title?.trim()) eventTags.push(['title', title.trim()]);
+      for (const tag of tags ?? []) {
+        if (tag.trim()) eventTags.push(['t', tag.trim().toLowerCase()]);
+      }
+      eventTags.push(['published_at', String(Math.floor(Date.now() / 1000))]);
+
+      return publish.mutateAsync({
+        kind: WEB_BOOKMARK_KIND,
+        content: description?.trim() ?? '',
+        tags: eventTags,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: queryKey(user?.pubkey) });
+    },
+  });
+}
+
+/**
+ * A NIP-09 deletion request. Relays are free to ignore it — deletion is a
+ * request, not a guarantee — so the removed bookmark is also dropped from
+ * the local cache directly rather than waiting on a relay refetch that may
+ * still hand it back.
+ */
+export function useDeleteWebBookmark() {
+  const { user } = useCurrentUser();
+  const publish = useNostrPublish();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (event: NostrEvent) => {
+      if (!user) throw new Error('Sign in to remove a bookmark');
+      const dTag = tagValue(event, 'd') ?? '';
+      return publish.mutateAsync({
+        kind: 5,
+        content: '',
+        tags: [
+          ['a', `${WEB_BOOKMARK_KIND}:${user.pubkey}:${dTag}`],
+          ['e', event.id],
+          ['k', String(WEB_BOOKMARK_KIND)],
+        ],
+      });
+    },
+    onSuccess: (_data, removed) => {
+      queryClient.setQueryData<NostrEvent[]>(queryKey(user?.pubkey), (current) =>
+        current?.filter((event) => event.id !== removed.id),
+      );
+    },
+  });
+}
+
+export function webBookmarkTopics(event: NostrEvent): string[] {
+  return tagValues(event, 't');
+}

--- a/src/os/registry.ts
+++ b/src/os/registry.ts
@@ -1,5 +1,5 @@
 import { lazy } from 'react';
-import { Activity, BookOpen, FileText, Info, Rss, Settings, User } from 'lucide-react';
+import { Activity, BookOpen, FileText, Info, Link2, Rss, Settings, User } from 'lucide-react';
 import type { AppDefinition } from './types';
 
 /**
@@ -48,6 +48,16 @@ export const APPS: AppDefinition[] = [
     component: lazy(() => import('@/apps/articles')),
     defaultSize: { width: 780, height: 760 },
     minSize: { width: 360, height: 320 },
+  },
+  {
+    id: 'web-bookmarks',
+    title: 'Web Bookmarks',
+    description: 'Links you have saved from around the web',
+    icon: Link2,
+    category: 'social',
+    component: lazy(() => import('@/apps/web-bookmarks')),
+    defaultSize: { width: 600, height: 660 },
+    minSize: { width: 340, height: 300 },
   },
   {
     id: 'relays',


### PR DESCRIPTION
## Summary

Implements NIP-B0 web bookmarks (kind `39701`) — split out from #21 since it's a different event shape: one addressable event per URL (with its own title/description/tags) rather than an entry in a NIP-51 list.

- `src/hooks/useWebBookmarks.ts`: `useMyWebBookmarks`, `useCreateWebBookmark`, `useDeleteWebBookmark`, and `bookmarkDTag`/`bookmarkUrl` implementing the spec's "strip `https://` for the `d` tag" rule (and reversing it for display/linking).
- Delete sends a NIP-09 kind `5` deletion request, and also removes the item from the local query cache directly — relays aren't obligated to honor deletion requests, so a plain refetch could still hand it back.
- `src/apps/web-bookmarks/index.tsx`: new app, registered in `src/os/registry.ts`. Inline "Add bookmark" form (URL, optional title/description/tags), list view with an external-link-out to the saved URL, tag badges, and a hover "Remove" action.
- `docs/apps.md` updated.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint --cache`
- [x] `npx vitest run src/hooks/useWebBookmarks.test.ts` — `bookmarkDTag`/`bookmarkUrl` round-trip for both `https://` and non-`https` schemes
- [x] Drove the running app with Playwright: logged in with a locally generated nsec, added a bookmark (URL + title + description + tags), confirmed the publish succeeded and a toast confirmed it, reloaded, and confirmed the Web Bookmarks app lists it with the stripped `d` tag, description and tag badges intact and opens the URL in a new tab.
- [x] Confirmed the signed-out state shows the sign-in prompt.

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYiUtZMQeA5RHggQw73wto