### PR TITLE
Keep feed actions visible across desktop and mobile

### DIFF
--- a/src/components/nostr/NoteCard.tsx
+++ b/src/components/nostr/NoteCard.tsx
@@ -51,7 +51,7 @@ export function NoteCard({ event, compact, className }: NoteCardProps) {
         <NoteContent content={event.content} />
 
         {!compact && (
-          <div className="mt-2 flex items-center gap-1">
+          <div className="mt-2 flex flex-wrap items-center gap-1">
             <Button
               variant="ghost"
               size="sm"

--- a/src/components/nostr/NoteCard.tsx
+++ b/src/components/nostr/NoteCard.tsx
@@ -51,7 +51,7 @@ export function NoteCard({ event, compact, className }: NoteCardProps) {
         <NoteContent content={event.content} />
 
         {!compact && (
-          <div className="mt-2 flex items-center gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
+          <div className="mt-2 flex items-center gap-1">
             <Button
               variant="ghost"
               size="sm"


### PR DESCRIPTION
## Summary
- `NoteCard`'s per-note action row (Open thread, Copy link, Bookmark) was hidden behind `opacity-0` + `group-hover`/`focus-within`, so the actions were invisible until a mouse hovered the note. That made them hard to discover on desktop and impossible to reach with touch-only input.
- Removed the hover-only opacity toggle so the action row renders visibly at all times, on every viewport size, for both pointer and touch input.
- `NoteCard` is shared across the feed, thread, profile, bookmarks, spells, and search apps, so this fixes visibility everywhere replies/notes are rendered as cards.

Existing behavior is unchanged otherwise: each button already has an accessible label, visible keyboard focus (via the shared `Button` component), and `BookmarkButton` already reflects pending/saved state and reports failures via toast.

Closes #52

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint src/components/nostr/NoteCard.tsx`
- [ ] Manually verify in a browser that actions are visible without hovering, on desktop and a narrow/mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYiUtZMQeA5RHggQw73wto