### PR TITLE
Fix follow/unfollow: fetch kind 3 fresh at write time

### DIFF
--- a/src/apps/profile/index.tsx
+++ b/src/apps/profile/index.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect } from 'react';
 import { useNostr } from '@nostrify/react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { Check, Copy, Globe, Loader2, UserMinus, UserPlus } from 'lucide-react';
 import type { NostrEvent } from '@nostrify/nostrify';
 import { AppBody, AppLayout, AppToolbar, EmptyState } from '@/components/os/AppChrome';
@@ -12,8 +12,7 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAuthor } from '@/hooks/useAuthor';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
-import { useMyFollows } from '@/hooks/useFollows';
-import { useNostrPublish } from '@/hooks/useNostrPublish';
+import { useMyFollows, useToggleFollow } from '@/hooks/useFollows';
 import { useToast } from '@/hooks/useToast';
 import { decodeRelayHints, displayName, isReply, npubOf, sanitizeUrl } from '@/lib/nostrUtils';
 import type { AppProps } from '@/os/types';
@@ -167,32 +166,23 @@ function CopyNpubButton({ pubkey }: { pubkey: string }) {
 }
 
 /**
- * Follows are a whole-list replacement (kind 3), so the current list has to be
- * read back before writing or the edit would silently drop everyone else.
+ * Follows are a whole-list replacement (kind 3). The toggle itself lives in
+ * `useToggleFollow`; this button only reflects the cached list and toasts.
  */
 function FollowButton({ pubkey }: { pubkey: string }) {
   const { user } = useCurrentUser();
-  const myFollows = useMyFollows();
-  const publish = useNostrPublish();
-  const queryClient = useQueryClient();
+  const { data: follows } = useMyFollows();
+  const toggleFollow = useToggleFollow();
   const { toast } = useToast();
 
-  const follows = useMemo(() => myFollows.data ?? [], [myFollows.data]);
-  const isFollowing = follows.includes(pubkey);
+  const isFollowing = (follows ?? []).includes(pubkey);
   const isSelf = user?.pubkey === pubkey;
 
   if (!user || isSelf) return null;
 
   const toggle = async () => {
-    const next = isFollowing ? follows.filter((key) => key !== pubkey) : [...follows, pubkey];
-
     try {
-      await publish.mutateAsync({
-        kind: 3,
-        content: '',
-        tags: next.map((key) => ['p', key]),
-      });
-      await queryClient.invalidateQueries({ queryKey: ['nostr', 'follows'] });
+      await toggleFollow.mutateAsync(pubkey);
       toast({ title: isFollowing ? 'Unfollowed' : 'Following' });
     } catch (error) {
       toast({
@@ -209,9 +199,9 @@ function FollowButton({ pubkey }: { pubkey: string }) {
       variant={isFollowing ? 'outline' : 'default'}
       className="h-7 gap-1.5 px-2.5 text-xs"
       onClick={toggle}
-      disabled={publish.isPending || myFollows.isLoading}
+      disabled={toggleFollow.isPending}
     >
-      {publish.isPending ? (
+      {toggleFollow.isPending ? (
         <Loader2 className="size-3.5 animate-spin" aria-hidden />
       ) : isFollowing ? (
         <UserMinus className="size-3.5" aria-hidden />

--- a/src/hooks/useFollows.ts
+++ b/src/hooks/useFollows.ts
@@ -1,29 +1,19 @@
 import { useNostr } from '@nostrify/react';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { NostrEvent } from '@nostrify/nostrify';
 import { useCurrentUser } from '@/hooks/useCurrentUser';
+import { useNostrPublish } from '@/hooks/useNostrPublish';
 
 /** The pubkeys in a user's kind 3 contact list. */
 export function useFollows(pubkey: string | undefined) {
   const { nostr } = useNostr();
 
   return useQuery<string[]>({
-    queryKey: ['nostr', 'follows', pubkey ?? ''],
+    queryKey: followsQueryKey(pubkey),
     enabled: Boolean(pubkey),
     queryFn: async ({ signal }) => {
-      const [event] = await nostr.query(
-        [{ kinds: [3], authors: [pubkey!], limit: 1 }],
-        { signal: AbortSignal.any([signal, AbortSignal.timeout(3000)]) },
-      );
-
-      if (!event) return [];
-
-      return [
-        ...new Set(
-          event.tags
-            .filter(([name, value]) => name === 'p' && typeof value === 'string')
-            .map(([, value]) => value),
-        ),
-      ];
+      const event = await fetchFollowEvent(nostr, pubkey!, signal);
+      return extractFollows(event?.tags ?? []);
     },
     staleTime: 5 * 60 * 1000,
   });
@@ -33,4 +23,91 @@ export function useFollows(pubkey: string | undefined) {
 export function useMyFollows() {
   const { user } = useCurrentUser();
   return useFollows(user?.pubkey);
+}
+
+function followsQueryKey(pubkey: string | undefined) {
+  return ['nostr', 'follows', pubkey ?? ''] as const;
+}
+
+/**
+ * Reads the user's current kind 3 event. Throws on timeout instead of
+ * resolving to an empty list — a failed read must never be mistaken for
+ * "follows nobody", because the caller is about to replace the whole list
+ * and an empty stand-in would silently wipe every real entry.
+ */
+async function fetchFollowEvent(
+  nostr: ReturnType<typeof useNostr>['nostr'],
+  pubkey: string,
+  signal?: AbortSignal,
+): Promise<NostrEvent | null> {
+  const timeout = AbortSignal.timeout(6000);
+  const events = await nostr.query(
+    [{ kinds: [3], authors: [pubkey], limit: 1 }],
+    { signal: AbortSignal.any([timeout, ...(signal ? [signal] : [])]) },
+  );
+  if (timeout.aborted || signal?.aborted) {
+    throw new Error('Could not read your follow list from your relays. Try again.');
+  }
+  return events[0] ?? null;
+}
+
+function extractFollows(tags: string[][]): string[] {
+  return [
+    ...new Set(
+      tags
+        .filter(([name, value]) => name === 'p' && typeof value === 'string')
+        .map(([, value]) => value),
+    ),
+  ];
+}
+
+interface ToggleFollowResult {
+  forPubkey: string;
+  follows: string[];
+}
+
+/**
+ * Follows are a whole-list replacement (kind 3), so the current list has to be
+ * read back before writing or the edit would silently drop everyone else.
+ *
+ * The list is fetched fresh from the relays at click time — not read from the
+ * query cache — and the computed result is written straight into the cache on
+ * success. Deliberately no `invalidateQueries` here: right after publishing,
+ * a re-query can still race back the pre-update list from a lagging relay and
+ * silently clobber this correct value (the same eventual-consistency race
+ * `useSetPubkeyMuted` documents). That race is what made unfollow appear to
+ * do nothing and, when the stale read came back empty, wiped whole lists.
+ */
+export function useToggleFollow() {
+  const { nostr } = useNostr();
+  const { user } = useCurrentUser();
+  const publish = useNostrPublish();
+  const queryClient = useQueryClient();
+
+  return useMutation<ToggleFollowResult, Error, string>({
+    mutationFn: async (target) => {
+      if (!user) throw new Error('Sign in to follow accounts');
+
+      const current = await fetchFollowEvent(nostr, user.pubkey);
+      const currentFollows = extractFollows(current?.tags ?? []);
+      const isFollowing = currentFollows.includes(target);
+
+      const follows = isFollowing
+        ? currentFollows.filter((key) => key !== target)
+        : [...currentFollows, target];
+
+      await publish.mutateAsync({
+        kind: 3,
+        content: current?.content ?? '',
+        tags: follows.map((key) => ['p', key]),
+      });
+
+      return { forPubkey: user.pubkey, follows };
+    },
+    // `forPubkey` is captured by mutationFn at call time so a stale callback
+    // can never write into another account's (or a logged-out) query key.
+    onSuccess: ({ forPubkey, follows }) => {
+      queryClient.setQueryData<string[]>(followsQueryKey(forPubkey), follows);
+    },
+  });
 }


### PR DESCRIPTION
This pull request refactors the follow/unfollow logic on the profile page to improve reliability and consistency, especially around updating the user's follow list. The main change is the introduction of a new `useToggleFollow` hook, which centralizes and streamlines the follow/unfollow mutation process, ensuring the local cache is updated correctly and avoiding issues with stale data from relays. The profile page is updated to use this new hook, simplifying the follow button logic.

**Follow/Unfollow Logic Refactor:**

* Added a new `useToggleFollow` hook in `useFollows.ts` that handles the entire follow/unfollow mutation, including fetching the latest follow list from relays, updating it, publishing the change, and updating the local cache without invalidating queries. This prevents race conditions that could previously wipe the follow list due to eventual consistency issues.
* Refactored the `FollowButton` in `profile/index.tsx` to use the new `useToggleFollow` hook, removing the manual publish and cache invalidation logic. The button now directly reflects the cached follow list and uses the new mutation for toggling follows.

**Code Simplification and Cleanup:**

* Removed unnecessary imports such as `useMemo`, `useQueryClient`, and `useNostrPublish` from `profile/index.tsx`, and updated the import for `useToggleFollow`. [[1]](diffhunk://#diff-13bda3afb368f8767794a6b7428d1d6b0164e575000bdfff82739e16dac870a2L1-R3) [[2]](diffhunk://#diff-13bda3afb368f8767794a6b7428d1d6b0164e575000bdfff82739e16dac870a2L15-R15)
* Updated the button's loading and disabled state logic to use the new mutation's status (`toggleFollow.isPending`) instead of the previous publish mutation.

**Supporting Utilities:**

* Added utility functions in `useFollows.ts` for fetching the latest follow event (`fetchFollowEvent`), extracting follows from tags (`extractFollows`), and generating consistent query keys (`followsQueryKey`).

These changes make the follow/unfollow flow more robust and maintainable, and prevent accidental data loss due to relay synchronization issues.